### PR TITLE
NOISSUE - Fix broken documentation links

### DIFF
--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -31,7 +31,7 @@ const jsonLd = {
         "https://github.com/absmach",
         "https://twitter.com/absmach",
         "https://www.linkedin.com/company/abstract-machines",
-        "https://www.youtube.com/@abstractmachines",
+        "https://www.youtube.com/@absmach",
       ],
       address: {
         "@type": "PostalAddress",

--- a/app/docs/[[...slug]]/page.tsx
+++ b/app/docs/[[...slug]]/page.tsx
@@ -81,7 +81,7 @@ export default async function Page(props: PageProps<"/docs/[[...slug]]">) {
 }
 
 export async function generateStaticParams() {
-  return source.generateParams();
+  return [{ slug: [] }, ...source.generateParams()];
 }
 
 export async function generateMetadata(

--- a/content/docs/dev-guide/architecture.mdx
+++ b/content/docs/dev-guide/architecture.mdx
@@ -64,10 +64,10 @@ Running Magistrala on gateway moves computation from cloud towards the edge thus
 [clients-service]: https://github.com/absmach/magistrala/tree/main/clients
 [channels-service]: https://github.com/absmach/magistrala/tree/main/channels
 [domains-service]: https://github.com/absmach/magistrala/tree/main/domains
-[http-adapter]: https://github.com/absmach/magistrala/tree/main/http
-[mqtt-adapter]: https://github.com/absmach/magistrala/tree/main/mqtt
-[coap-adapter]: https://github.com/absmach/magistrala/tree/main/coap
-[ws-adapter]: https://github.com/absmach/magistrala/tree/main/ws
+[http-adapter]: /docs/dev-guide/dev-tools/messaging#http
+[mqtt-adapter]: /docs/dev-guide/dev-tools/messaging#mqtt
+[coap-adapter]: /docs/dev-guide/dev-tools/messaging#coap
+[ws-adapter]: /docs/dev-guide/dev-tools/messaging#websocket
 [magistrala-cli]: https://github.com/absmach/magistrala/tree/main/cli
 [bootstrap]: https://github.com/absmach/magistrala/tree/main/bootstrap
 [consumers]: https://github.com/absmach/magistrala/tree/main/consumers

--- a/content/docs/dev-guide/architecture.mdx
+++ b/content/docs/dev-guide/architecture.mdx
@@ -14,10 +14,6 @@ Magistrala IoT platform is comprised of the following services:
 | [clients][clients-service]       | Manages platform's clients and auth concerns in regards to clients                            |
 | [channels][channels-service]     | Manages platform's channels and auth concerns in regards to channels                          |
 | [domains][domains-service]       | Manages platform's domains and auth concerns in regards to domains                            |
-| [http-adapter][http-adapter]     | Provides an HTTP interface for sending messages via HTTP                                      |
-| [mqtt-adapter][mqtt-adapter]     | Provides an MQTT and MQTT over WS interface for sending and receiving messages via MQTT       |
-| [ws-adapter][ws-adapter]         | Provides a WebSocket interface for sending and receiving messages via WS                      |
-| [coap-adapter][coap-adapter]     | Provides a CoAP interface for sending and receiving messages via CoAP                         |
 | [magistrala-cli][magistrala-cli] | Command line interface                                                                        |
 | [bootstrap][bootstrap]           | Provides basic configuration for newly created clients                                        |
 | [consumers][consumers]           | Receives messages and persists or forwards them to configured destinations                    |
@@ -49,10 +45,9 @@ In general, there is no constraint put on content that is being exchanged throug
 
 ## Edge
 
-Magistrala platform can be run on the edge as well. Deploying Magistrala on a gateway makes it able to collect, store and analyze data, organize and authenticate devices. To connect Magistrala instances running on a gateway with Magistrala in a cloud we can use two gateway services developed for that purpose:
+Magistrala platform can be run on the edge as well. Deploying Magistrala on a gateway makes it able to collect, store and analyze data, organize and authenticate devices. To connect Magistrala instances running on a gateway with Magistrala in a cloud we can use the following gateway service:
 
 - [Agent][agent]
-- [Export][export]
 
 ## Unified IoT Platform
 
@@ -64,10 +59,6 @@ Running Magistrala on gateway moves computation from cloud towards the edge thus
 [clients-service]: https://github.com/absmach/magistrala/tree/main/clients
 [channels-service]: https://github.com/absmach/magistrala/tree/main/channels
 [domains-service]: https://github.com/absmach/magistrala/tree/main/domains
-[http-adapter]: /docs/dev-guide/dev-tools/messaging#http
-[mqtt-adapter]: /docs/dev-guide/dev-tools/messaging#mqtt
-[coap-adapter]: /docs/dev-guide/dev-tools/messaging#coap
-[ws-adapter]: /docs/dev-guide/dev-tools/messaging#websocket
 [magistrala-cli]: https://github.com/absmach/magistrala/tree/main/cli
 [bootstrap]: https://github.com/absmach/magistrala/tree/main/bootstrap
 [consumers]: https://github.com/absmach/magistrala/tree/main/consumers
@@ -80,4 +71,3 @@ Running Magistrala on gateway moves computation from cloud towards the edge thus
 [kafka]: https://kafka.apache.org/
 [senml]: https://tools.ietf.org/html/draft-ietf-core-senml-08
 [agent]: /docs/dev-guide/edge#agent
-[export]: /docs/dev-guide/edge#export

--- a/content/docs/dev-guide/benchmark.mdx
+++ b/content/docs/dev-guide/benchmark.mdx
@@ -145,8 +145,8 @@ TBD
 [mzbench]: https://github.com/mzbench/mzbench
 [vmq_mzbench]: https://github.com/vernemq/vmq_mzbench
 [mzb_api_ec2_plugin]: https://github.com/mzbench/mzbench/blob/master/doc/cloud_plugins.md#amazon-ec2
-[satori]: https://github.com/satori-com/mzbench
+[satori]: https://github.com/mzbench/mzbench
 [mzbench-cli]: https://github.com/mzbench/mzbench/blob/master/doc/cli.md
 [mzbench-dashboard]: https://github.com/mzbench/mzbench/blob/master/doc/dashboard.md
 [mg-benchmark]: https://github.com/absmach/benchmark/tree/master/mzbench
-[mzbench-scenarios]: https://github.com/mzbench/mzbench/blob/master/scenarios/spec.md#pre_hook-and-post_hook
+[mzbench-scenarios]: https://github.com/mzbench/mzbench/tree/master/doc

--- a/content/docs/dev-guide/certs.mdx
+++ b/content/docs/dev-guide/certs.mdx
@@ -5,7 +5,7 @@ keywords:
   - Certificates
   - Certs
   - PKI
-  - Vault
+  - OpenBao
   - mTLS
   - Security
   - X.509
@@ -21,28 +21,26 @@ Provisioning is a process of configuration of an IoT platform in which system op
 Issues certificates for clients. `Certs` service can create certificates to be used when `Magistrala` is deployed to support mTLS.  
 `Certs` service will create certificate for valid client ID if valid user token is passed and user is owner of the provided client ID.
 
-Certificate service can create certificates in PKI mode - where certificates issued by PKI, when you deploy `Vault` as PKI certificate management `cert` service will proxy requests to `Vault` previously checking access rights and saving info on successfully created certificate.
+Certificate service can create certificates in PKI mode - where certificates issued by PKI, when you deploy `OpenBao` as PKI certificate management `cert` service will proxy requests to the configured PKI previously checking access rights and saving info on successfully created certificate.
 
 ### PKI mode
 
-When `MG_CERTS_VAULT_HOST` is set, it is presumed that `Vault` is installed and `certs` service will issue certificates using `Vault` API.
+When `MG_CERTS_VAULT_HOST` is set, it is presumed that `OpenBao` is installed and `certs` service will issue certificates using the configured PKI API.
 
-First you'll need to set up `Vault`.
+First you'll need to set up `OpenBao`.
 
-To setup `Vault` follow steps in [Build Your Own Certificate Authority (CA)][vault-pki-engine].
+To setup `OpenBao` follow the [PKI secrets engine setup and usage guide][openbao-pki-setup].
 
-To setup certs service with `Vault` following environment variables must be set:
+To setup certs service with `OpenBao` following environment variables must be set:
 
 ```bash
 MG_CERTS_VAULT_HOST=vault-domain.com
 MG_CERTS_VAULT_PKI_PATH=<vault_pki_path>
 MG_CERTS_VAULT_ROLE=<vault_role>
-MG_CERTS_VAULT_TOKEN=<vault_acces_token>
+MG_CERTS_VAULT_TOKEN=<openbao_access_token>
 ```
 
-For lab purposes you can use docker-compose and script for setting up PKI in [meodor-vault][meodor-vault].
-
-Make sure you have an already running instance of `Magistrala` , `Vault` and `Certs` service.
+Make sure you have an already running instance of `Magistrala`, `OpenBao` and `Certs` service.
 
 To start Magistrala run:
 
@@ -50,25 +48,7 @@ To start Magistrala run:
 make run_latest args="-d"
 ```
 
-To start vault run:
-
-```bash
-make run_addons vault up args="-d"
-```
-
-When vault service is up and running some initializations steps must be done to setup clients for `Certs` service. For more information about this steps please check [magistrala-vault][magistrala-vault]
-
-```bash
-bash docker/addons/vault/vault-init.sh
-bash docker/addons/vault/vault-unseal.sh
-bash docker/addons/vault/vault-set-pki.sh
-```
-
-`vault-init.sh` initializes Vault, generates unseal keys and root tokens, and updates corresponding environment variables in the `.env` file. It's important to securely store these keys as they are required to unseal Vault.
-
-`vault-unseal.sh` is used to unseal Vault after initialization, but it's typically not needed since Vault can unseal itself when starting the container.
-
-`vault-set-pki.sh` generates certificates for Vault, including root and intermediate certificates, and copies them to the `docker/ssl/certs` folder. The CA parameters are sourced from environment variables in the `.env` file.
+OpenBao deployment and PKI bootstrap steps are documented separately. Until then, configure OpenBao PKI before starting `certs`.
 
 To start certs service run:
 
@@ -86,12 +66,6 @@ To stop certs service run:
 
 ```bash
 make run_addons certs down
-```
-
-To stop vault service run:
-
-```bash
-make run_addons vault down
 ```
 
 This step can be skipped if you already have a client ID.
@@ -165,7 +139,5 @@ revoked: 2023-09-14 11:21:44 +0000 UTC
 
 For more information about the Certification service, please check out the [Certs documentation][api-docs].
 
-[vault-pki-engine]: https://learn.hashicorp.com/tutorials/vault/pki-engine
-[meodor-vault]: https://github.com/mteodor/vault
+[openbao-pki-setup]: https://openbao.org/docs/secrets/pki/setup/
 [api-docs]: https://docs.api.magistrala.absmach.eu/?urls.primaryName=api%2Fhttp.yaml&service=certs.yaml
-[magistrala-vault]: https://github.com/absmach/magistrala/tree/main/docker/addons/vault

--- a/content/docs/dev-guide/certs.mdx
+++ b/content/docs/dev-guide/certs.mdx
@@ -163,9 +163,9 @@ magistrala-cli certs revoke f13f0f30-f923-4504-8a7a-6aa45bcb4866 $USER_TOKEN
 revoked: 2023-09-14 11:21:44 +0000 UTC
 ```
 
-For more information about the Certification service API, please check out the [API documentation][api-docs].
+For more information about the Certification service, please check out the [Certs documentation][api-docs].
 
 [vault-pki-engine]: https://learn.hashicorp.com/tutorials/vault/pki-engine
 [meodor-vault]: https://github.com/mteodor/vault
-[api-docs]: https://docs.api.magistrala.absmach.eu/?urls.primaryName=api%2Fcerts.yaml
-[magistrala-vault]: https://github.com/absmach/magistrala/tree/main/docker/addons/vault
+[api-docs]: https://docs.api.magistrala.absmach.eu/?urls.primaryName=api%2Fcerts.yaml&service=certs.yaml
+[magistrala-vault]: https://github.com/absmach/supermq/tree/main/docker/addons/vault

--- a/content/docs/dev-guide/certs.mdx
+++ b/content/docs/dev-guide/certs.mdx
@@ -167,5 +167,5 @@ For more information about the Certification service, please check out the [Cert
 
 [vault-pki-engine]: https://learn.hashicorp.com/tutorials/vault/pki-engine
 [meodor-vault]: https://github.com/mteodor/vault
-[api-docs]: https://docs.api.magistrala.absmach.eu/?urls.primaryName=api%2Fcerts.yaml&service=certs.yaml
-[magistrala-vault]: https://github.com/absmach/supermq/tree/main/docker/addons/vault
+[api-docs]: https://docs.api.magistrala.absmach.eu/?urls.primaryName=api%2Fhttp.yaml&service=certs.yaml
+[magistrala-vault]: https://github.com/absmach/magistrala/tree/main/docker/addons/vault

--- a/content/docs/dev-guide/cli/channels-cli.mdx
+++ b/content/docs/dev-guide/cli/channels-cli.mdx
@@ -151,7 +151,7 @@ Expected result:
 }
 ```
 
-See [Metadata Management](../../user-guide/metadata#api--cli-integration) for the full format reference.
+See [Metadata Management](/docs/user-guide/metadata#api--cli-integration) for the full format reference.
 
 ### Enable Channel
 

--- a/content/docs/dev-guide/cli/clients-cli.mdx
+++ b/content/docs/dev-guide/cli/clients-cli.mdx
@@ -116,7 +116,7 @@ To have the metadata recognized and displayed correctly by the Magistrala UI (wi
 magistrala-cli clients update <client_id> '{"name":"value1", "metadata":{"key1":{"value":"value2","type":"string","updatedAt":"2026-01-01T00:00:00.000Z"}}}' <user_token>
 ```
 
-See [Metadata Management](../../user-guide/metadata#api--cli-integration) for the full format reference.
+See [Metadata Management](/docs/user-guide/metadata#api--cli-integration) for the full format reference.
 
 Example usage:
 

--- a/content/docs/dev-guide/cli/domains-cli.mdx
+++ b/content/docs/dev-guide/cli/domains-cli.mdx
@@ -155,7 +155,7 @@ To have the metadata recognized and displayed correctly by the Magistrala UI, us
 magistrala-cli domains update 16a4ad70-a385-45c5-b50a-6d7e48d768d7 '{"name":"domain_name","alias":"domain_alias","metadata":{"location":{"value":"london","type":"string","updatedAt":"2026-01-01T00:00:00.000Z"}}}' token
 ```
 
-See [Metadata Management](../../user-guide/metadata#api--cli-integration) for the full format reference.
+See [Metadata Management](/docs/user-guide/metadata#api--cli-integration) for the full format reference.
 
 After running the command, you should see an output similar to this:
 

--- a/content/docs/dev-guide/cli/introduction-to-cli.mdx
+++ b/content/docs/dev-guide/cli/introduction-to-cli.mdx
@@ -18,13 +18,13 @@ It can be installed as a standalone binary, built from source, or run via Docker
 
 ## Installation
 
-### Option 1 — Download Latest Release
+### Option 1 — Check Latest Release
 
-The latest tagged version of **magistrala-cli** is available for download from the Magistrala releases page:
+The latest Magistrala release is published on the Magistrala releases page:
 
 [Download the latest Magistrala CLI release](https://github.com/absmach/magistrala/releases)
 
-When a new version of Magistrala is released, a new `magistrala-cli` binary will also be available under the release assets.
+Recent Magistrala releases do not consistently publish `magistrala-cli` binaries under the release assets. If you need the CLI locally, use one of the installation methods below.
 
 ### Option 2 — Build from Source
 

--- a/content/docs/dev-guide/dev-tools/authentication.mdx
+++ b/content/docs/dev-guide/dev-tools/authentication.mdx
@@ -128,7 +128,7 @@ MG_GOOGLE_STATE=pGXVNhEeKfycuBzk5InlSfMlEU9UrhlkTUOSqhsgDzXP2Y4RsN
 For a local Docker-based environment, add the following lines to your .env or docker-compose.env:
 
 ```bash
-## In the SMQ
+## In the Magistrala
 
 SMQ_GOOGLE_CLIENT_ID=985229335584-m2mft8lqbgfn5gfw9ftrm3r2sgu4tsrw.apps.googleusercontent.com
 SMQ_GOOGLE_CLIENT_SECRET=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WYUIpw

--- a/content/docs/dev-guide/dev-tools/authentication.mdx
+++ b/content/docs/dev-guide/dev-tools/authentication.mdx
@@ -305,10 +305,10 @@ mosquitto_sub -I <client_name> -u <client_id> -P <client_secret> --cafile docker
 ```
 
 [jwt]: https://jwt.io/
-[messaging]: ./messaging
+[messaging]: /docs/dev-guide/dev-tools/messaging
 [rf5280]: https://tools.ietf.org/html/rfc5280
-[ssl-makefile]: https://github.com/absmach/magistrala/blob/main/docker/ssl/Makefile
-[provision]: ./provision
+[ssl-makefile]: https://github.com/absmach/supermq/blob/main/docker/ssl/Makefile
+[provision]: /docs/dev-guide/services/provision
 [openssl]: https://www.openssl.org/
 [vault]: https://www.vaultproject.io/
 [oidc]: https://openid.net/connect/

--- a/content/docs/dev-guide/dev-tools/authentication.mdx
+++ b/content/docs/dev-guide/dev-tools/authentication.mdx
@@ -307,7 +307,7 @@ mosquitto_sub -I <client_name> -u <client_id> -P <client_secret> --cafile docker
 [jwt]: https://jwt.io/
 [messaging]: /docs/dev-guide/dev-tools/messaging
 [rf5280]: https://tools.ietf.org/html/rfc5280
-[ssl-makefile]: https://github.com/absmach/supermq/blob/main/docker/ssl/Makefile
+[ssl-makefile]: https://github.com/absmach/magistrala/blob/main/docker/ssl/Makefile
 [provision]: /docs/dev-guide/services/provision
 [openssl]: https://www.openssl.org/
 [vault]: https://www.vaultproject.io/

--- a/content/docs/dev-guide/dev-tools/authentication.mdx
+++ b/content/docs/dev-guide/dev-tools/authentication.mdx
@@ -313,4 +313,4 @@ mosquitto_sub -I <client_name> -u <client_id> -P <client_secret> --cafile docker
 [vault]: https://www.vaultproject.io/
 [oidc]: https://openid.net/connect/
 [google-identity-platform]: https://cloud.google.com/identity-platform/docs/
-[google-identity-platform-docs]: https://support.google.com/cloud/answer/6158849?hl=en
+[google-identity-platform-docs]: https://cloud.google.com/identity-platform/docs/web/google

--- a/content/docs/dev-guide/dev-tools/events.mdx
+++ b/content/docs/dev-guide/dev-tools/events.mdx
@@ -2353,4 +2353,4 @@ Example of disconnect event:
 
 [redis-streams]: https://redis.io/topics/streams-intro
 [mg-docker-compose]: https://github.com/absmach/magistrala/blob/main/docker/docker-compose.yaml
-[bootstrap-docker-compose]: https://github.com/absmach/magistrala/blob/main/docker/addons/bootstrap/docker-compose.yml
+[bootstrap-docker-compose]: https://github.com/absmach/magistrala/blob/main/docker/addons/bootstrap/docker-compose.yaml

--- a/content/docs/dev-guide/dev-tools/messaging.mdx
+++ b/content/docs/dev-guide/dev-tools/messaging.mdx
@@ -534,7 +534,7 @@ For more information and examples checkout [official nats.io documentation][nats
 [rfc7252]: https://tools.ietf.org/html/rfc7252
 [coap-cli]: https://github.com/absmach/coap-cli
 [rfc7641]: https://tools.ietf.org/html/rfc7641#page-18
-[coap]: https://github.com/absmach/supermq/tree/main/coap
+[coap]: https://github.com/absmach/magistrala/tree/main/coap
 [mqtt-over-websockets]: https://www.hivemq.com/blog/mqtt-essentials-special-mqtt-over-websockets/#:~:text=In%20MQTT%20over%20WebSockets%2C%20the,(WebSockets%20also%20leverage%20TCP).
 [paho-js]: https://www.eclipse.org/paho/index.php?page=clients/js/index.php
 [mqttjs]: https://github.com/mqttjs/MQTT.js

--- a/content/docs/dev-guide/dev-tools/messaging.mdx
+++ b/content/docs/dev-guide/dev-tools/messaging.mdx
@@ -528,13 +528,13 @@ When Unsubscribing from a channel, the reader is closed.
 For more information and examples checkout [official nats.io documentation][nats], [official rabbitmq documentation][rabbitmq], [official vernemq documentation][vernemq] and [official kafka documentation][kafka].
 
 [nats-jestream]: https://docs.nats.io/nats-concepts/jetstream
-[http-api]: https://docs.api.magistrala.absmach.eu/?urls.primaryName=api%2Fhttp.yaml
+[http-api]: https://docs.api.magistrala.absmach.eu/?urls.primaryName=api%2Fhttp.yaml&service=http.yaml
 [mosquitto]: https://mosquitto.org
 [paho]: https://www.eclipse.org/paho/
 [rfc7252]: https://tools.ietf.org/html/rfc7252
 [coap-cli]: https://github.com/absmach/coap-cli
 [rfc7641]: https://tools.ietf.org/html/rfc7641#page-18
-[coap]: https://www.github.com/absmach/magistrala/tree/main/coap/README.md
+[coap]: https://github.com/absmach/supermq/tree/main/coap
 [mqtt-over-websockets]: https://www.hivemq.com/blog/mqtt-essentials-special-mqtt-over-websockets/#:~:text=In%20MQTT%20over%20WebSockets%2C%20the,(WebSockets%20also%20leverage%20TCP).
 [paho-js]: https://www.eclipse.org/paho/index.php?page=clients/js/index.php
 [mqttjs]: https://github.com/mqttjs/MQTT.js
@@ -545,4 +545,4 @@ For more information and examples checkout [official nats.io documentation][nats
 [kafka]: https://kafka.apache.org/documentation/
 [nats-mqtt]: https://docs.nats.io/running-a-nats-service/configuration/mqtt
 [mqtt-v3.1.1]: https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html
-[certs]: ../certs
+[certs]: /docs/dev-guide/certs

--- a/content/docs/dev-guide/dev-tools/messaging.mdx
+++ b/content/docs/dev-guide/dev-tools/messaging.mdx
@@ -534,7 +534,7 @@ For more information and examples checkout [official nats.io documentation][nats
 [rfc7252]: https://tools.ietf.org/html/rfc7252
 [coap-cli]: https://github.com/absmach/coap-cli
 [rfc7641]: https://tools.ietf.org/html/rfc7641#page-18
-[coap]: https://github.com/absmach/magistrala/tree/main/coap
+[coap]: https://github.com/absmach/coap-cli
 [mqtt-over-websockets]: https://www.hivemq.com/blog/mqtt-essentials-special-mqtt-over-websockets/#:~:text=In%20MQTT%20over%20WebSockets%2C%20the,(WebSockets%20also%20leverage%20TCP).
 [paho-js]: https://www.eclipse.org/paho/index.php?page=clients/js/index.php
 [mqttjs]: https://github.com/mqttjs/MQTT.js

--- a/content/docs/dev-guide/dev-tools/storage.mdx
+++ b/content/docs/dev-guide/dev-tools/storage.mdx
@@ -261,9 +261,9 @@ To start Timescale reader, execute the following command:
 docker-compose -f docker/addons/timescale-reader/docker-compose.yml up -d
 ```
 
-[subtopic]: ./messaging#subtopics
+[subtopic]: /docs/dev-guide/dev-tools/messaging#subtopics
 [nats-subject]: https://docs.nats.io/nats-concepts/subjects
 [nats-wildcards]: https://docs.nats.io/nats-concepts/subjects#wildcards
-[writers]: ./storage#writers
+[writers]: /docs/dev-guide/dev-tools/storage#writers
 [influxdb]: https://docs.influxdata.com/influxdb
-[readers-api]: https://github.com/absmach/magistrala/blob/main/api/openapi/readers.yml
+[readers-api]: https://docs.supermq.absmach.eu/storage/#readers

--- a/content/docs/dev-guide/dev-tools/storage.mdx
+++ b/content/docs/dev-guide/dev-tools/storage.mdx
@@ -266,4 +266,4 @@ docker-compose -f docker/addons/timescale-reader/docker-compose.yml up -d
 [nats-wildcards]: https://docs.nats.io/nats-concepts/subjects#wildcards
 [writers]: /docs/dev-guide/dev-tools/storage#writers
 [influxdb]: https://docs.influxdata.com/influxdb
-[readers-api]: https://docs.supermq.absmach.eu/storage/#readers
+[readers-api]: https://magistrala.absmach.eu/docs/dev-guide/services/readers/

--- a/content/docs/dev-guide/dev-tools/tracing.mdx
+++ b/content/docs/dev-guide/dev-tools/tracing.mdx
@@ -68,4 +68,4 @@ This is just a brief overview of the possibilities of Jaeger and its UI. For mor
 
 [jaegertracing]: https://www.jaegertracing.io/
 [jaeger-ui]: https://www.jaegertracing.io/docs/1.14/frontend-ui/
-[getting-started]: ../getting-started
+[getting-started]: /docs/dev-guide/getting-started

--- a/content/docs/dev-guide/edge.mdx
+++ b/content/docs/dev-guide/edge.mdx
@@ -578,10 +578,10 @@ magistrala-mqtt   | {"level":"info","message":"Publish - client ID export-88529f
 [provision]: /docs/dev-guide/services/provision
 [edgex-repo]: https://github.com/edgexfoundry/edgex-go
 [conftoml]: https://github.com/absmach/export/blob/master/configs/config.toml
-[docker-compose]: https://github.com/absmach/supermq/blob/main/docker/docker-compose.yaml
+[docker-compose]: https://github.com/absmach/magistrala/blob/main/docker/docker-compose.yml
 [env]: https://github.com/absmach/export#environmet-variables
 [mutual-tls]: /docs/dev-guide/dev-tools/authentication#mutual-tls-authentication-with-x509-certificates
 [certs-service]: /docs/dev-guide/certs#certs-service
-[protomsg]: https://github.com/absmach/supermq/blob/main/pkg/messaging/message.proto
+[protomsg]: https://github.com/absmach/magistrala/blob/main/pkg/messaging/message.proto
 [back-to-edge]: /docs/dev-guide/edge
 [nats]: https://nats.io/

--- a/content/docs/dev-guide/edge.mdx
+++ b/content/docs/dev-guide/edge.mdx
@@ -38,7 +38,7 @@ Agent service has following features:
 
 - Remote execution of commands
 - Remote terminal, remote session to `bash` managed by `Agent`
-- Heartbeat - listening to Message Broker topic `heartbeat.>` it can remotely provide info on running services, if services are publishing heartbeat ( like [Export](./edge#export))
+- Heartbeat - listening to Message Broker topic `heartbeat.>` it can remotely provide info on running services, if services are publishing heartbeat ( like [Export](/docs/dev-guide/edge#export))
 - Proxying commands to other gateway services
 - Edgex SMA - remotely making requests to EdgeX endpoints and fetching results, if EdgeX is deployed.
 
@@ -570,18 +570,18 @@ In Magistrala `mqtt` service:
 magistrala-mqtt   | {"level":"info","message":"Publish - client ID export-88529fb2-6c1e-4b60-b9ab-73b5d89f7404 to the topic: m/6a45444c-4c89-46f9-a284-9e731674726a/c/e2adcfa6-96b2-425d-8cd4-ff8cb9c056ce/export/test","ts":"2020-05-08T15:16:02.999684791Z"}
 ```
 
-[agent]: ./edge#agent
-[export]: ./edge#export
-[magistrala]: ../user-guide/architecture
-[bootstrap]: ./services/bootstrap
-[bootstraping]: ./services/bootstrap#bootstrapping
-[provision]: ./services/provision
+[agent]: /docs/dev-guide/edge#agent
+[export]: /docs/dev-guide/edge#export
+[magistrala]: /docs/user-guide/architecture
+[bootstrap]: /docs/dev-guide/services/bootstrap
+[bootstraping]: /docs/dev-guide/services/bootstrap#bootstrapping
+[provision]: /docs/dev-guide/services/provision
 [edgex-repo]: https://github.com/edgexfoundry/edgex-go
 [conftoml]: https://github.com/absmach/export/blob/master/configs/config.toml
-[docker-compose]: https://github.com/absmach/magistrala/blob/main/docker/docker-compose.yml
+[docker-compose]: https://github.com/absmach/supermq/blob/main/docker/docker-compose.yaml
 [env]: https://github.com/absmach/export#environmet-variables
-[mutual-tls]: ./dev-tools/authentication#mutual-tls-authentication-with-x509-certificates
-[certs-service]: ./certs#certs-service
-[protomsg]: https://github.com/absmach/magistrala/blob/main/pkg/messaging/message.proto
-[back-to-edge]: ./edge
+[mutual-tls]: /docs/dev-guide/dev-tools/authentication#mutual-tls-authentication-with-x509-certificates
+[certs-service]: /docs/dev-guide/certs#certs-service
+[protomsg]: https://github.com/absmach/supermq/blob/main/pkg/messaging/message.proto
+[back-to-edge]: /docs/dev-guide/edge
 [nats]: https://nats.io/

--- a/content/docs/dev-guide/edge.mdx
+++ b/content/docs/dev-guide/edge.mdx
@@ -578,7 +578,7 @@ magistrala-mqtt   | {"level":"info","message":"Publish - client ID export-88529f
 [provision]: /docs/dev-guide/services/provision
 [edgex-repo]: https://github.com/edgexfoundry/edgex-go
 [conftoml]: https://github.com/absmach/export/blob/master/configs/config.toml
-[docker-compose]: https://github.com/absmach/magistrala/blob/main/docker/docker-compose.yml
+[docker-compose]: https://github.com/absmach/magistrala/blob/main/docker/docker-compose.yaml
 [env]: https://github.com/absmach/export#environmet-variables
 [mutual-tls]: /docs/dev-guide/dev-tools/authentication#mutual-tls-authentication-with-x509-certificates
 [certs-service]: /docs/dev-guide/certs#certs-service

--- a/content/docs/dev-guide/entities.mdx
+++ b/content/docs/dev-guide/entities.mdx
@@ -387,13 +387,13 @@ Supported types are: `string`, `integer`, `double`, `boolean`, `json`, `location
 
 Entities provisioned via the API or CLI with raw (unwrapped) values — e.g. `{"myKey": "my value"}` — are accepted and displayed in the UI, but will not have type tracking or an `updatedAt` timestamp. To ensure full UI compatibility, use the wrapped format above.
 
-For complete details on metadata value types and the location/perimeter formats used by dashboard map widgets, see the [Metadata Management](../user-guide/metadata) user guide.
+For complete details on metadata value types and the location/perimeter formats used by dashboard map widgets, see the [Metadata Management](/docs/user-guide/metadata) user guide.
 
 > **Note:** Older deployments may store UI-managed metadata under a nested `ui` key (i.e. `metadata.ui`) rather than at the top level. A database migration is provided to flatten this structure automatically — existing users only need to upgrade to the latest version of Magistrala.
 
 [clients-api]: ./api#clients
 [channels-api]: ./api#channels
 [domains-api]: ./api#domains
-[clients-cli]: ./cli/clients-cli
-[channels-cli]: ./cli/channels-cli
-[domains-cli]: ./cli/domains-cli
+[clients-cli]: /docs/dev-guide/cli/clients-cli
+[channels-cli]: /docs/dev-guide/cli/channels-cli
+[domains-cli]: /docs/dev-guide/cli/domains-cli

--- a/content/docs/dev-guide/extensions/lora.mdx
+++ b/content/docs/dev-guide/extensions/lora.mdx
@@ -96,10 +96,10 @@ The lora-adapter uses the metadata of provision events emitted by Magistrala sys
 
 To forward LoRa messages the lora-adapter subscribes to topics `applications/+/devices/+` of the LoRa Server MQTT broker. It verifies the `app_id` and the `dev_eui` of received messages. If the mapping exists it uses corresponding `Channel ID` and `Client ID` to sign and forwards the content of the LoRa message to the Magistrala message broker.
 
-[lora-adapter]: https://github.com/absmach/supermq-contrib/tree/main/lora
+[lora-adapter]: https://github.com/absmach/magistrala-contrib/tree/main/lora
 [lora-server]: https://www.chirpstack.io/
 [lora-gateway]: https://www.chirpstack.io/docs/gateway-bridge/
 [semtech]: https://www.chirpstack.io/docs/chirpstack-gateway-bridge/backends/semtech-udp.html
 [lora-app-server]: https://www.chirpstack.io/docs/chirpstack/use/index.html
-[lora-docker-compose]: https://github.com/absmach/supermq-contrib/blob/main/docker/addons/lora-adapter/docker-compose.yml
+[lora-docker-compose]: https://github.com/absmach/magistrala-contrib/blob/main/docker/lora-adapter/docker-compose.yml
 [redis]: https://redis.io/

--- a/content/docs/dev-guide/extensions/lora.mdx
+++ b/content/docs/dev-guide/extensions/lora.mdx
@@ -1,6 +1,6 @@
 ---
 title: LoRa
-description: Bridge LoRaWAN to Magistrala with the LoRa adapter—map Applications/Devices to Channels/Clients and forward JSON/SenML over MQTT.
+description: Bridge LoRaWAN to Magistrala with the LoRa adapter using ChirpStack, mapping Applications and Devices to Channels and Clients and forwarding JSON or SenML over MQTT.
 keywords:
   - LoRaWAN
   - LoRa adapter
@@ -13,57 +13,53 @@ keywords:
 image: /img/mg-preview.png
 ---
 
-Bridging with LoRaWAN Networks can be done over the [lora-adapter][lora-adapter]. This service sits between Magistrala and [LoRa Server][lora-server] and just forwards the messages from one system to another via MQTT protocol, using the adequate MQTT topics and in the good message format (JSON and SenML), i.e. respecting the APIs of both systems.
+Bridging LoRaWAN networks to Magistrala can be done with the [lora-adapter][lora-adapter]. This service sits between Magistrala and [ChirpStack][chirpstack] and forwards messages between the two systems over MQTT using compatible topic structures and payload formats such as JSON and SenML.
 
-LoRa Server is used for connectivity layer. Specially for the [LoRa Gateway Bridge][lora-gateway] service, which abstracts the [SemTech packet-forwarder UDP protocol][semtech] into JSON over MQTT. But also for the [LoRa Server][lora-server] service, responsible of the de-duplication and handling of uplink frames received by the gateway(s), handling of the LoRaWAN mac-layer and scheduling of downlink data transmissions. Finally the [Lora App Server][lora-app-server] services is used to interact with the system.
+Historically this page referred to "LoRa Server", "LoRa App Server", and "LoRa Gateway Bridge". These projects are now part of the [ChirpStack][chirpstack] ecosystem. In current ChirpStack deployments, the [ChirpStack Gateway Bridge][chirpstack-gateway-bridge] handles gateway connectivity and abstracts protocols such as the [Semtech UDP packet-forwarder][semtech], while ChirpStack itself provides device, application, gateway, and tenant management through its web interface and APIs.
 
-## Run Lora Server
+## Run ChirpStack
 
-Before to run the `lora-adapter` you must install and run LoRa Server. First, execute the following command:
-
-```bash
-go get github.com/brocaar/loraserver-docker
-```
-
-Once everything is installed, execute the following command from the LoRa Server project root:
+Before running the `lora-adapter`, install and run ChirpStack. The simplest path is the official Docker Compose quickstart:
 
 ```bash
-docker-compose up
+git clone https://github.com/chirpstack/chirpstack-docker.git
+cd chirpstack-docker
+docker compose up
 ```
 
-**Troubleshooting:** Magistrala and LoRa Server use their own MQTT brokers which by default occupy MQTT port `1883`. If both are ran on the same machine different ports must be used. You can fix this on Magistrala side by configuring the environment variable `MG_MQTT_ADAPTER_MQTT_PORT`.
+For current ChirpStack deployment guidance, refer to the [official Docker quickstart][chirpstack-docker].
 
-## Setup LoRa Server
+**Troubleshooting:** Magistrala and ChirpStack may each use MQTT components that default to port `1883`. If both are running on the same machine, you may need to reconfigure ports. On the Magistrala side, this can be addressed with `MG_MQTT_ADAPTER_MQTT_PORT`.
 
-Now that both systems are running you must provision LoRa Server, which offers for integration with external services, a RESTful and gRPC API. You can do it as well over the [LoRa App Server][lora-app-server], which is good example of integration.
+## Setup ChirpStack
 
-- **Create an Organization:** To add your own Gateways to the network you must have an Organization.
-- **Create a Network:** Set the address of your Network-Server API that is used by LoRa App Server or other custom components interacting with LoRa Server (by default loraserver:8000).
-- **Create a Gateways-Profile:** In this profile you can select the radio LoRa channels and the LoRa Network Server to use.
-- **Create a Service-profile:** A service-profile connects an organization to a network-server and defines the features that an organization can use on this Network-Server.
-- **Create a Gateway:** You must set proper ID in order to be discovered by LoRa Server.
-- **Create an Application:** This will allows you to create Devices by connecting them to this application. This is equivalent to Devices connected to channels in Magistrala.
-- **Create a Device-Profile:** Before creating Device you must create Device profile where you will define some parameter as LoRaWAN MAC version (format of the device address) and the LoRaWAN regional parameter (frequency band). This will allow you to create many devices using this profile.
-- **Create a Device:** Finally, you can create a Device. You must configure the `network session key` and `application session key` of your Device. You can generate and copy them on your device configuration or you can use your own pre generated keys and set them using the LoRa App Server UI.
-  Device connect through OTAA. Make sure that loraserver device-profile is using same release as device. If MAC version is 1.0.X, `application key = app_key` and `app_eui = deviceEUI`. If MAC version is 1.1 or ABP both parameters will be needed, APP_key and Network key.
+Once both systems are running, configure ChirpStack for your gateway and devices. ChirpStack exposes a web interface plus APIs for this setup.
 
-## Magistrala and LoRa Server
+- **Create a tenant:** In modern ChirpStack, tenants replace the older organization-style grouping. See [Tenants][chirpstack-tenants].
+- **Connect a gateway:** Register and configure your gateway so ChirpStack can receive uplinks. See [Connecting a gateway][chirpstack-connect-gateway].
+- **Create an application:** Devices are grouped under applications in ChirpStack.
+- **Create a device profile:** Define the LoRaWAN MAC version, region, and device capabilities. See [Device profiles][chirpstack-device-profiles].
+- **Create a device:** Add the device and configure OTAA or ABP activation settings as needed. See [Connecting a device][chirpstack-connect-device].
 
-Once everything is running and the LoRa Server is provisioned, execute the following command from Magistrala project root to run the lora-adapter:
+## Magistrala and ChirpStack
+
+Once everything is running and ChirpStack is provisioned, clone the contrib repository and run the lora-adapter from there:
 
 ```bash
-docker-compose -f docker/addons/lora-adapter/docker-compose.yml up -d
+git clone https://github.com/absmach/supermq-contrib.git
+cd supermq-contrib
+docker compose -f docker/addons/lora-adapter/docker-compose.yml up -d
 ```
 
-**Troubleshooting:** The lora-adapter subscribes to the LoRa Server MQTT broker and will fail if the connection is not established. You must ensure that the environment variable `MG_LORA_ADAPTER_MESSAGES_URL` is properly configured.
+**Troubleshooting:** The lora-adapter subscribes to the ChirpStack MQTT broker and will fail if the connection is not established. You must ensure that the environment variable `MG_LORA_ADAPTER_MESSAGES_URL` is properly configured.
 
 **Remark:** By default, `MG_LORA_ADAPTER_MESSAGES_URL` is set as `tcp://lora.mqtt.magistrala.io:1883` in the [docker-compose.yml][lora-docker-compose] file of the adapter. If you run the composition without configure this variable you will start to receive messages from our demo server.
 
 ### Route Map
 
-The lora-adapter use [Redis][redis] database to create a route map between both systems. As in Magistrala we use Channels to connect Clients, LoRa Server uses Applications to connect Devices.
+The lora-adapter uses [Redis][redis] to create a route map between both systems. In Magistrala, channels connect clients; in ChirpStack, applications group devices.
 
-The lora-adapter uses the metadata of provision events emitted by Magistrala system to update his route map. For that, you must provision Magistrala Channels and Clients with an extra metadata key in the JSON Body of the HTTP request. It must be a JSON object with key `lora` which value is another JSON object. This nested JSON object should contain `app_id` or `dev_eui` field. In this case `app_id` or `dev_eui` must be an existent Lora application ID or device EUI:
+The lora-adapter uses metadata from Magistrala provision events to update its route map. To do this, provision Magistrala channels and clients with an extra metadata key in the JSON body of the HTTP request. It must be a JSON object with key `lora`, whose value is another JSON object. This nested JSON object should contain `app_id` or `dev_eui`. In both cases, the value must correspond to an existing ChirpStack application ID or device EUI:
 
 **Channel structure:**
 
@@ -94,12 +90,16 @@ The lora-adapter uses the metadata of provision events emitted by Magistrala sys
 
 #### Messaging
 
-To forward LoRa messages the lora-adapter subscribes to topics `applications/+/devices/+` of the LoRa Server MQTT broker. It verifies the `app_id` and the `dev_eui` of received messages. If the mapping exists it uses corresponding `Channel ID` and `Client ID` to sign and forwards the content of the LoRa message to the Magistrala message broker.
+To forward LoRa messages, the lora-adapter subscribes to ChirpStack MQTT uplink topics. In current adapter configuration, this is controlled by `SMQ_LORA_ADAPTER_MESSAGES_TOPIC`, which commonly uses a pattern such as `application/+/device/+/event/up`. The adapter verifies the `app_id` and the `dev_eui` of received messages. If the mapping exists, it uses the corresponding `Channel ID` and `Client ID` to sign and forward the content of the LoRa message to the Magistrala message broker.
 
-[lora-adapter]: https://github.com/absmach/magistrala/tree/main/lora
-[lora-server]: https://www.loraserver.io
-[lora-gateway]: https://www.loraserver.io/lora-gateway-bridge/overview/
-[semtech]: https://github.com/Lora-net/packet_forwarder/blob/master/PROTOCOL.TXT
-[lora-app-server]: https://www.loraserver.io/lora-app-server/overview/
-[lora-docker-compose]: https://github.com/absmach/magistrala/blob/master/docker/addons/lora-adapter/docker-compose.yml
+[lora-adapter]: https://github.com/absmach/supermq-contrib/tree/main/lora
+[chirpstack]: https://www.chirpstack.io/
+[chirpstack-docker]: https://www.chirpstack.io/docs/getting-started/docker.html
+[chirpstack-gateway-bridge]: https://www.chirpstack.io/docs/gateway-bridge/index.html
+[chirpstack-tenants]: https://www.chirpstack.io/docs/chirpstack/use/tenants.html
+[chirpstack-connect-gateway]: https://www.chirpstack.io/docs/guides/connect-gateway.html
+[chirpstack-device-profiles]: https://www.chirpstack.io/docs/chirpstack/use/device-profiles.html
+[chirpstack-connect-device]: https://www.chirpstack.io/docs/guides/connect-device.html
+[semtech]: https://www.chirpstack.io/docs/chirpstack-gateway-bridge/backends/semtech-udp.html
+[lora-docker-compose]: https://github.com/absmach/supermq-contrib/blob/main/docker/addons/lora-adapter/docker-compose.yml
 [redis]: https://redis.io/

--- a/content/docs/dev-guide/extensions/lora.mdx
+++ b/content/docs/dev-guide/extensions/lora.mdx
@@ -1,6 +1,6 @@
 ---
 title: LoRa
-description: Bridge LoRaWAN to Magistrala with the LoRa adapter using ChirpStack, mapping Applications and Devices to Channels and Clients and forwarding JSON or SenML over MQTT.
+description: Bridge LoRaWAN to Magistrala with the LoRa adapter—map Applications/Devices to Channels/Clients and forward JSON/SenML over MQTT.
 keywords:
   - LoRaWAN
   - LoRa adapter
@@ -13,53 +13,57 @@ keywords:
 image: /img/mg-preview.png
 ---
 
-Bridging LoRaWAN networks to Magistrala can be done with the [lora-adapter][lora-adapter]. This service sits between Magistrala and [ChirpStack][chirpstack] and forwards messages between the two systems over MQTT using compatible topic structures and payload formats such as JSON and SenML.
+Bridging with LoRaWAN Networks can be done over the [lora-adapter][lora-adapter]. This service sits between Magistrala and [LoRa Server][lora-server] and just forwards the messages from one system to another via MQTT protocol, using the adequate MQTT topics and in the good message format (JSON and SenML), i.e. respecting the APIs of both systems.
 
-Historically this page referred to "LoRa Server", "LoRa App Server", and "LoRa Gateway Bridge". These projects are now part of the [ChirpStack][chirpstack] ecosystem. In current ChirpStack deployments, the [ChirpStack Gateway Bridge][chirpstack-gateway-bridge] handles gateway connectivity and abstracts protocols such as the [Semtech UDP packet-forwarder][semtech], while ChirpStack itself provides device, application, gateway, and tenant management through its web interface and APIs.
+LoRa Server is used for connectivity layer. Specially for the [LoRa Gateway Bridge][lora-gateway] service, which abstracts the [SemTech packet-forwarder UDP protocol][semtech] into JSON over MQTT. But also for the [LoRa Server][lora-server] service, responsible of the de-duplication and handling of uplink frames received by the gateway(s), handling of the LoRaWAN mac-layer and scheduling of downlink data transmissions. Finally the [Lora App Server][lora-app-server] services is used to interact with the system.
 
-## Run ChirpStack
+## Run Lora Server
 
-Before running the `lora-adapter`, install and run ChirpStack. The simplest path is the official Docker Compose quickstart:
-
-```bash
-git clone https://github.com/chirpstack/chirpstack-docker.git
-cd chirpstack-docker
-docker compose up
-```
-
-For current ChirpStack deployment guidance, refer to the [official Docker quickstart][chirpstack-docker].
-
-**Troubleshooting:** Magistrala and ChirpStack may each use MQTT components that default to port `1883`. If both are running on the same machine, you may need to reconfigure ports. On the Magistrala side, this can be addressed with `MG_MQTT_ADAPTER_MQTT_PORT`.
-
-## Setup ChirpStack
-
-Once both systems are running, configure ChirpStack for your gateway and devices. ChirpStack exposes a web interface plus APIs for this setup.
-
-- **Create a tenant:** In modern ChirpStack, tenants replace the older organization-style grouping. See [Tenants][chirpstack-tenants].
-- **Connect a gateway:** Register and configure your gateway so ChirpStack can receive uplinks. See [Connecting a gateway][chirpstack-connect-gateway].
-- **Create an application:** Devices are grouped under applications in ChirpStack.
-- **Create a device profile:** Define the LoRaWAN MAC version, region, and device capabilities. See [Device profiles][chirpstack-device-profiles].
-- **Create a device:** Add the device and configure OTAA or ABP activation settings as needed. See [Connecting a device][chirpstack-connect-device].
-
-## Magistrala and ChirpStack
-
-Once everything is running and ChirpStack is provisioned, clone the contrib repository and run the lora-adapter from there:
+Before to run the `lora-adapter` you must install and run LoRa Server. First, execute the following command:
 
 ```bash
-git clone https://github.com/absmach/supermq-contrib.git
-cd supermq-contrib
-docker compose -f docker/addons/lora-adapter/docker-compose.yml up -d
+go get github.com/brocaar/loraserver-docker
 ```
 
-**Troubleshooting:** The lora-adapter subscribes to the ChirpStack MQTT broker and will fail if the connection is not established. You must ensure that the environment variable `MG_LORA_ADAPTER_MESSAGES_URL` is properly configured.
+Once everything is installed, execute the following command from the LoRa Server project root:
+
+```bash
+docker-compose up
+```
+
+**Troubleshooting:** Magistrala and LoRa Server use their own MQTT brokers which by default occupy MQTT port `1883`. If both are ran on the same machine different ports must be used. You can fix this on Magistrala side by configuring the environment variable `MG_MQTT_ADAPTER_MQTT_PORT`.
+
+## Setup LoRa Server
+
+Now that both systems are running you must provision LoRa Server, which offers for integration with external services, a RESTful and gRPC API. You can do it as well over the [LoRa App Server][lora-app-server], which is good example of integration.
+
+- **Create an Organization:** To add your own Gateways to the network you must have an Organization.
+- **Create a Network:** Set the address of your Network-Server API that is used by LoRa App Server or other custom components interacting with LoRa Server (by default loraserver:8000).
+- **Create a Gateways-Profile:** In this profile you can select the radio LoRa channels and the LoRa Network Server to use.
+- **Create a Service-profile:** A service-profile connects an organization to a network-server and defines the features that an organization can use on this Network-Server.
+- **Create a Gateway:** You must set proper ID in order to be discovered by LoRa Server.
+- **Create an Application:** This will allows you to create Devices by connecting them to this application. This is equivalent to Devices connected to channels in Magistrala.
+- **Create a Device-Profile:** Before creating Device you must create Device profile where you will define some parameter as LoRaWAN MAC version (format of the device address) and the LoRaWAN regional parameter (frequency band). This will allow you to create many devices using this profile.
+- **Create a Device:** Finally, you can create a Device. You must configure the `network session key` and `application session key` of your Device. You can generate and copy them on your device configuration or you can use your own pre generated keys and set them using the LoRa App Server UI.
+  Device connect through OTAA. Make sure that loraserver device-profile is using same release as device. If MAC version is 1.0.X, `application key = app_key` and `app_eui = deviceEUI`. If MAC version is 1.1 or ABP both parameters will be needed, APP_key and Network key.
+
+## Magistrala and LoRa Server
+
+Once everything is running and the LoRa Server is provisioned, execute the following command from Magistrala project root to run the lora-adapter:
+
+```bash
+docker-compose -f docker/addons/lora-adapter/docker-compose.yml up -d
+```
+
+**Troubleshooting:** The lora-adapter subscribes to the LoRa Server MQTT broker and will fail if the connection is not established. You must ensure that the environment variable `MG_LORA_ADAPTER_MESSAGES_URL` is properly configured.
 
 **Remark:** By default, `MG_LORA_ADAPTER_MESSAGES_URL` is set as `tcp://lora.mqtt.magistrala.io:1883` in the [docker-compose.yml][lora-docker-compose] file of the adapter. If you run the composition without configure this variable you will start to receive messages from our demo server.
 
 ### Route Map
 
-The lora-adapter uses [Redis][redis] to create a route map between both systems. In Magistrala, channels connect clients; in ChirpStack, applications group devices.
+The lora-adapter use [Redis][redis] database to create a route map between both systems. As in Magistrala we use Channels to connect Clients, LoRa Server uses Applications to connect Devices.
 
-The lora-adapter uses metadata from Magistrala provision events to update its route map. To do this, provision Magistrala channels and clients with an extra metadata key in the JSON body of the HTTP request. It must be a JSON object with key `lora`, whose value is another JSON object. This nested JSON object should contain `app_id` or `dev_eui`. In both cases, the value must correspond to an existing ChirpStack application ID or device EUI:
+The lora-adapter uses the metadata of provision events emitted by Magistrala system to update his route map. For that, you must provision Magistrala Channels and Clients with an extra metadata key in the JSON Body of the HTTP request. It must be a JSON object with key `lora` which value is another JSON object. This nested JSON object should contain `app_id` or `dev_eui` field. In this case `app_id` or `dev_eui` must be an existent Lora application ID or device EUI:
 
 **Channel structure:**
 
@@ -90,16 +94,12 @@ The lora-adapter uses metadata from Magistrala provision events to update its ro
 
 #### Messaging
 
-To forward LoRa messages, the lora-adapter subscribes to ChirpStack MQTT uplink topics. In current adapter configuration, this is controlled by `SMQ_LORA_ADAPTER_MESSAGES_TOPIC`, which commonly uses a pattern such as `application/+/device/+/event/up`. The adapter verifies the `app_id` and the `dev_eui` of received messages. If the mapping exists, it uses the corresponding `Channel ID` and `Client ID` to sign and forward the content of the LoRa message to the Magistrala message broker.
+To forward LoRa messages the lora-adapter subscribes to topics `applications/+/devices/+` of the LoRa Server MQTT broker. It verifies the `app_id` and the `dev_eui` of received messages. If the mapping exists it uses corresponding `Channel ID` and `Client ID` to sign and forwards the content of the LoRa message to the Magistrala message broker.
 
 [lora-adapter]: https://github.com/absmach/supermq-contrib/tree/main/lora
-[chirpstack]: https://www.chirpstack.io/
-[chirpstack-docker]: https://www.chirpstack.io/docs/getting-started/docker.html
-[chirpstack-gateway-bridge]: https://www.chirpstack.io/docs/gateway-bridge/index.html
-[chirpstack-tenants]: https://www.chirpstack.io/docs/chirpstack/use/tenants.html
-[chirpstack-connect-gateway]: https://www.chirpstack.io/docs/guides/connect-gateway.html
-[chirpstack-device-profiles]: https://www.chirpstack.io/docs/chirpstack/use/device-profiles.html
-[chirpstack-connect-device]: https://www.chirpstack.io/docs/guides/connect-device.html
+[lora-server]: https://www.chirpstack.io/
+[lora-gateway]: https://www.chirpstack.io/docs/gateway-bridge/
 [semtech]: https://www.chirpstack.io/docs/chirpstack-gateway-bridge/backends/semtech-udp.html
+[lora-app-server]: https://www.chirpstack.io/docs/chirpstack/use/index.html
 [lora-docker-compose]: https://github.com/absmach/supermq-contrib/blob/main/docker/addons/lora-adapter/docker-compose.yml
 [redis]: https://redis.io/

--- a/content/docs/dev-guide/extensions/magistrala-contrib.mdx
+++ b/content/docs/dev-guide/extensions/magistrala-contrib.mdx
@@ -69,17 +69,17 @@ The **magistrala-contrib** repository is a dynamic and collaborative space for d
 - **Add your own contributions**: Developers are encouraged to fork the repository, experiment with ideas, and submit pull requests for review.
 - **Collaborate with the community**: Join the discussion and help improve existing contributions.
 
-Visit the [magistrala-contrib GitHub Repository](https://github.com/absmach/supermq-contrib) to get started!
+Visit the [magistrala-contrib GitHub Repository](https://github.com/absmach/magistrala-contrib) to get started!
 
 ## Conclusion
 
 The **magistrala-contrib** repository complements the Magistrala platform by extending its functionality and fostering innovation. Whether you are a contributor or an end-user, the tools and services in this repository enable you to enhance your IoT infrastructure and explore advanced use cases.
 
-[lora]: https://github.com/absmach/supermq-contrib/tree/main/lora
-[opcua]: https://github.com/absmach/supermq-contrib/tree/main/opcua
-[twins]: https://github.com/absmach/supermq-contrib/tree/main/twins
-[mongodb]: https://github.com/absmach/supermq-contrib/tree/main/readers/mongodb
-[cassandra]: https://github.com/absmach/supermq-contrib/tree/main/readers/cassandra
-[influx]: https://github.com/absmach/supermq-contrib/tree/main/readers/influxdb
-[readers]: https://github.com/absmach/supermq-contrib/tree/main/readers
-[consumers]: https://github.com/absmach/supermq-contrib/tree/main/consumers
+[lora]: https://github.com/absmach/magistrala-contrib/tree/main/lora
+[opcua]: https://github.com/absmach/magistrala-contrib/tree/main/opcua
+[twins]: https://github.com/absmach/magistrala-contrib/tree/main/twins
+[mongodb]: https://github.com/absmach/magistrala-contrib/tree/main/readers/mongodb
+[cassandra]: https://github.com/absmach/magistrala-contrib/tree/main/readers/cassandra
+[influx]: https://github.com/absmach/magistrala-contrib/tree/main/readers/influxdb
+[readers]: https://github.com/absmach/magistrala-contrib/tree/main/readers
+[consumers]: https://github.com/absmach/magistrala-contrib/tree/main/consumers

--- a/content/docs/dev-guide/extensions/magistrala-contrib.mdx
+++ b/content/docs/dev-guide/extensions/magistrala-contrib.mdx
@@ -9,6 +9,8 @@ The repository acts as a playground for exploring and testing new ideas and cont
 
 This repository is an excellent starting point for developers looking to contribute new features or experiment with custom services and integrations for Magistrala.
 
+> Note: The services in `magistrala-contrib` are legacy contrib services and have been obsolete for a while.
+
 ## Available Services in magistrala-contrib
 
 ### LoRa
@@ -67,17 +69,17 @@ The **magistrala-contrib** repository is a dynamic and collaborative space for d
 - **Add your own contributions**: Developers are encouraged to fork the repository, experiment with ideas, and submit pull requests for review.
 - **Collaborate with the community**: Join the discussion and help improve existing contributions.
 
-Visit the [magistrala-contrib GitHub Repository](https://github.com/absmach/magistrala-contrib) to get started!
+Visit the [magistrala-contrib GitHub Repository](https://github.com/absmach/supermq-contrib) to get started!
 
 ## Conclusion
 
 The **magistrala-contrib** repository complements the Magistrala platform by extending its functionality and fostering innovation. Whether you are a contributor or an end-user, the tools and services in this repository enable you to enhance your IoT infrastructure and explore advanced use cases.
 
-[lora]: https://github.com/absmach/magistrala-contrib/tree/main/lora
-[opcua]: https://github.com/absmach/magistrala-contrib/tree/main/opcua
-[twins]: https://github.com/absmach/magistrala-contrib/tree/main/twins
-[mongodb]: https://github.com/absmach/magistrala-contrib/tree/main/readers/mongodb
-[cassandra]: https://github.com/absmach/magistrala-contrib/tree/main/readers/cassandra
-[influx]: https://github.com/absmach/magistrala-contrib/tree/main/readers/influxdb
-[readers]: https://github.com/absmach/magistrala-contrib/tree/main/readers
-[consumers]: https://github.com/absmach/magistrala-contrib/tree/main/consumers
+[lora]: https://github.com/absmach/supermq-contrib/tree/main/lora
+[opcua]: https://github.com/absmach/supermq-contrib/tree/main/opcua
+[twins]: https://github.com/absmach/supermq-contrib/tree/main/twins
+[mongodb]: https://github.com/absmach/supermq-contrib/tree/main/readers/mongodb
+[cassandra]: https://github.com/absmach/supermq-contrib/tree/main/readers/cassandra
+[influx]: https://github.com/absmach/supermq-contrib/tree/main/readers/influxdb
+[readers]: https://github.com/absmach/supermq-contrib/tree/main/readers
+[consumers]: https://github.com/absmach/supermq-contrib/tree/main/consumers

--- a/content/docs/dev-guide/extensions/opcua.mdx
+++ b/content/docs/dev-guide/extensions/opcua.mdx
@@ -127,7 +127,7 @@ The OPC-UA adapter can be used in an industrial setup to monitor process values 
 
 Clients on magistrala can be created to represent these devices and the channels can be created to represent the data points on the devices. The OPC-UA adapter can then be used to subscribe to the OPC-UA server and forward the data to the NATS message broker. This data can then be consumed by other services in the Magistrala system, and further processing done if need be.
 
-[opcua-adapter]: https://github.com/absmach/magistrala-contrib/tree/main/opcua
+[opcua-adapter]: https://github.com/absmach/supermq-contrib/tree/main/opcua
 [opcua-arch]: https://en.wikipedia.org/wiki/OPC_Unified_Architecture
 [public-opcua]: https://github.com/node-opcua/node-opcua/wiki/publicly-available-OPC-UA-Servers-and-Clients
 [redis]: https://redis.io/

--- a/content/docs/dev-guide/extensions/opcua.mdx
+++ b/content/docs/dev-guide/extensions/opcua.mdx
@@ -127,7 +127,7 @@ The OPC-UA adapter can be used in an industrial setup to monitor process values 
 
 Clients on magistrala can be created to represent these devices and the channels can be created to represent the data points on the devices. The OPC-UA adapter can then be used to subscribe to the OPC-UA server and forward the data to the NATS message broker. This data can then be consumed by other services in the Magistrala system, and further processing done if need be.
 
-[opcua-adapter]: https://github.com/absmach/supermq-contrib/tree/main/opcua
+[opcua-adapter]: https://github.com/absmach/magistrala-contrib/tree/main/opcua
 [opcua-arch]: https://en.wikipedia.org/wiki/OPC_Unified_Architecture
 [public-opcua]: https://github.com/node-opcua/node-opcua/wiki/publicly-available-OPC-UA-Servers-and-Clients
 [redis]: https://redis.io/

--- a/content/docs/dev-guide/extensions/twins.mdx
+++ b/content/docs/dev-guide/extensions/twins.mdx
@@ -346,5 +346,5 @@ Since messages published on message broker are republished on any other protocol
 [writer]: /docs/dev-guide/dev-tools/storage
 [senml]: https://tools.ietf.org/html/rfc8428#section-4.3
 [authentication]: /docs/dev-guide/dev-tools/authentication
-[twins-api]: https://github.com/absmach/supermq-contrib/tree/main/twins
+[twins-api]: https://github.com/absmach/magistrala-contrib/tree/main/twins
 [messaging]: /docs/dev-guide/dev-tools/messaging

--- a/content/docs/dev-guide/extensions/twins.mdx
+++ b/content/docs/dev-guide/extensions/twins.mdx
@@ -5,6 +5,8 @@ title: Twins Service
 
 Magistrala twins service is built on top of the Magistrala platform. In order to fully understand what follows, be sure to get acquainted with [overall Magistrala architecture][architecture].
 
+> Note: Twins is a contrib service and has been obsolete for a while.
+
 ## What is Digital Twin
 
 **Twin** refers to a **digital representation** of a **real world data system** consisting of possibly multiple data sources/producers and/or destinations/consumers (data agents).
@@ -344,5 +346,5 @@ Since messages published on message broker are republished on any other protocol
 [writer]: /docs/dev-guide/dev-tools/storage
 [senml]: https://tools.ietf.org/html/rfc8428#section-4.3
 [authentication]: /docs/dev-guide/dev-tools/authentication
-[twins-api]: https://github.com/absmach/magistrala/blob/main/api/openapi/twins.yml
+[twins-api]: https://github.com/absmach/supermq-contrib/tree/main/twins
 [messaging]: /docs/dev-guide/dev-tools/messaging

--- a/content/docs/dev-guide/getting-started.mdx
+++ b/content/docs/dev-guide/getting-started.mdx
@@ -607,8 +607,8 @@ sh scripts/combine-schema.sh
 [docker]: https://docs.docker.com/install/
 [docker-compose]: https://docs.docker.com/compose/install/
 [mg-releases]: https://github.com/absmach/magistrala/releases
-[cli]: ./cli/introduction-to-cli
-[provisioning]: ./cli/provision-cli
+[cli]: /docs/dev-guide/cli/introduction-to-cli
+[provisioning]: /docs/dev-guide/cli/provision-cli
 [magistrala-repo]: https://github.com/absmach/magistrala
 [golang-protobuf]: https://github.com/golang/protobuf
 [protobuf-install]: https://github.com/golang/protobuf#installation

--- a/content/docs/dev-guide/getting-started.mdx
+++ b/content/docs/dev-guide/getting-started.mdx
@@ -254,17 +254,13 @@ If you want to clean your whole dockerized Magistrala installation you can use t
 
 The **Magistrala CLI** is the primary interface for interacting with the system.
 
-Open a new terminal from which you can interact with the running Magistrala system. The easiest way to do this is by using the Magistrala CLI, which can be downloaded as a tarball from GitHub (here we use release `0.14.0` but be sure to use the [latest CLI release][mg-releases]):
-
-```bash
-wget -O- https://github.com/absmach/magistrala/releases/download/0.14.0/magistrala-cli_0.14.0_linux-amd64.tar.gz | tar xvz -C $GOBIN
-```
+Open a new terminal from which you can interact with the running Magistrala system. The Magistrala releases page is available at [latest CLI release][mg-releases], but recent releases do not publish CLI tarball assets. Build the CLI from source as described in the [CLI guide][cli].
 
 > Make sure that `$GOBIN` is added to your `$PATH` so that `magistrala-cli` command can be accessible system-wide
 
 #### Build magistrala-cli
 
-Build `magistrala-cli` if the pre-built CLI is not compatible with your OS, i.e MacOS. Please see the [CLI][cli] for further details.
+Build `magistrala-cli` by following the [CLI guide][cli].
 
 ### Step 6 - Provision the System
 

--- a/content/docs/dev-guide/getting-started.mdx
+++ b/content/docs/dev-guide/getting-started.mdx
@@ -615,9 +615,9 @@ sh scripts/combine-schema.sh
 [docker-compose-ref]: https://docs.docker.com/compose/reference/overview/
 [docker-compose-extend]: https://docs.docker.com/compose/extends/
 [go-cross-compile]: https://dave.cheney.net/2015/08/22/cross-compilation-with-go-1-5
-[go-arm]: https://www.alexruf.net/golang/arm/raspberrypi/2016/01/16/cross-compile-with-go-1-5-for-raspberry-pi.html
+[go-arm]: https://dave.cheney.net/2015/08/22/cross-compilation-with-go-1-5
 [wiki-go-arm]: https://go.dev/wiki/GoArm
 [vernemq]: https://vernemq.com/downloads/
-[postgres-roles]: https://support.rackspace.com/how-to/postgresql-creating-and-dropping-roles/
+[postgres-roles]: https://www.postgresql.org/docs/current/role-membership.html
 [nats]: https://www.nats.io/
 [postgresql]: https://www.postgresql.org/

--- a/content/docs/dev-guide/services/alarms.mdx
+++ b/content/docs/dev-guide/services/alarms.mdx
@@ -13,7 +13,7 @@ slug: dev-guide/alarms
 The **Alarms service** in Magistrala allows users to create alarms triggered by threshold conditions defined in the Rules Engine. When a rule is triggered, the system generates an alarm with relevant information.
 The documentation below highlights the basic structure of an alarm and how to interact with the alarms service API.
 
-> **Note:** Access to alarm operations is governed by domain-level and rule-level roles. Refer to the [Roles Schema](../roles-schema#alarms) for details on available roles and permissions.
+> **Note:** Access to alarm operations is governed by domain-level and rule-level roles. Refer to the [Roles Schema](/docs/dev-guide/roles-schema#alarms) for details on available roles and permissions.
 
 ## Core concepts
 
@@ -96,7 +96,7 @@ The Alarms service provides the following API endpoints for managing alarms:
 
 Alarm is creation is handled by the rules engine. This is done by creating a rule whose output is an alarm. When the threshold condition defined by the rule is met, an alarm is automatically generated.
 
-To create a rule that generates alarms, refer to the [Rules Engine documentation](./rules-engine).
+To create a rule that generates alarms, refer to the [Rules Engine documentation](/docs/dev-guide/services/rules-engine).
 
 Or simply:
 

--- a/content/docs/dev-guide/services/provision.mdx
+++ b/content/docs/dev-guide/services/provision.mdx
@@ -63,7 +63,7 @@ access-control-expose-headers: Location
 {"access_token":"eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Mzk0ODU4MDYsImlhdCI6MTczOTQ4MjIwNiwiaXNzIjoic3VwZXJtcS5hdXRoIiwidHlwZSI6MCwidXNlciI6IjBkNDA5NDgyLTA3MzctNDVlYS04Mjg0LTViZDg4MDU5ZjYyNSJ9.nFeihdM7KQJKr_2WQaKUFqBGWVw1qfjh0N6Uc5C6UXc2ugtm4LCf0sjDawi9ok_szk0fQeWWX8bqOsnEvhobZA","refresh_token":"eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3Mzk1Njg2MDYsImlhdCI6MTczOTQ4MjIwNiwiaXNzIjoic3VwZXJtcS5hdXRoIiwidHlwZSI6MSwidXNlciI6IjBkNDA5NDgyLTA3MzctNDVlYS04Mjg0LTViZDg4MDU5ZjYyNSJ9.DbaMpgVPtL7ER5wlsFmVtC3izKgjB66qsl1beT0qnlcWcfp7NQyvBtT0EW3OyibcqG56SnqO0ye1mzaJLgViqg"}
 ```
 
-For more information about the Users service API, please check out the [API documentation](https://docs.api.magistrala.absmach.eu/?urls.primaryName=api%2Fusers.yaml).
+For more information about the Users service API, please check out the [API documentation](https://docs.api.magistrala.absmach.eu/?urls.primaryName=api%2Fhttp.yaml&service=users.yaml).
 
 ## System Provisioning
 
@@ -387,13 +387,13 @@ date: Tue, 04 Apr 2023 09:57:53 GMT
 access-control-expose-headers: Location
 ```
 
-For more information about the Clients service API, please check out the [API documentation](https://docs.api.magistrala.absmach.eu/?urls.primaryName=api%2Fclients.yaml).
+For more information about the Clients service API, please check out the [API documentation](https://docs.api.magistrala.absmach.eu/?urls.primaryName=api%2Fhttp.yaml&service=clients.yaml).
 
 ## Provision Service
 
 Provisioning is a process of configuration of an IoT platform in which system operator creates and sets-up different entities used in the platform - users, channels and clients. It is part of process of setting up IoT applications where we connect devices on edge with platform in cloud. For provisioning we can use [Magistrala CLI][cli] for creating users and for each node in the edge (eg. gateway) required number of clients, channels, connecting them and creating certificates if needed. Provision service is used to set up initial application configuration once user is created. Provision service creates clients, channels, connections and certificates. Once user is created we can use provision to create a setup for edge node in one HTTP request instead of issuing several CLI commands.
 
-Provision service provides an HTTP API to interact with [Magistrala][provision-api].
+Provision service provides an HTTP API to interact with SuperMQ.
 
 For gateways to communicate with [Magistrala][magistrala] configuration is required (MQTT host, client, channels, certificates...). Gateway will send a request to [Bootstrap][bootstrap] service providing `<external_id>` and `<external_key>` in HTTP request to get the configuration. To make a request to [Bootstrap][bootstrap] service you can use [Agent][agent] service on a gateway.
 
@@ -410,7 +410,7 @@ Provision service provides a way of specifying this `provision layout` and creat
 
 The service is configured using the environment variables presented in the following [table][config]. Note that any unset variables will be replaced with their default values.
 
-By default, call to `/mapping` endpoint will create one client and two channels (`control` and `data`) and connect it as this is typical setup required by [Agent](./edge#agent). If there is a requirement for different provision layout we can use [config][conftoml] file in addition to environment variables.
+By default, call to `/mapping` endpoint will create one client and two channels (`control` and `data`) and connect it as this is typical setup required by [Agent](/docs/dev-guide/edge#agent). If there is a requirement for different provision layout we can use [config][conftoml] file in addition to environment variables.
 
 For the purposes of running provision as an add-on in docker composition environment variables seems more suitable. Environment variables are set in [.env][env].
 
@@ -655,17 +655,17 @@ MG_AGENT_BOOTSTRAP_ID=gateway MG_AGENT_BOOTSTRAP_KEY=external_key MG_AGENT_BOOTS
 
 Agent will retrieve connections parameters and connect to Magistrala cloud.
 
-For more information about the Provision service API, please check out this [API documentation](https://github.com/absmach/magistrala/tree/main/provision#readme).
+For more information about the Provision service, please check out the [service source and implementation][provision-api].
 
 [magistrala]: https://github.com/absmach/magistrala
-[bootstrap]: https://github.com/absmach/magistrala/tree/main/bootstrap
+[bootstrap]: /docs/dev-guide/services/bootstrap
 [agent]: https://github.com/absmach/agent
-[config]: https://github.com/absmach/magistrala/tree/main/provision#configuration
-[env]: https://github.com/absmach/magistrala/blob/main/docker/.env
+[config]: https://github.com/absmach/supermq/tree/main/provision#configuration
+[env]: https://github.com/absmach/supermq/blob/main/docker/.env
 [mgui]: https://github.com/absmach/magistrala-ui-new
-[conftoml]: https://github.com/absmach/magistrala/blob/main/docker/addons/provision/configs/config.toml
-[users]: https://github.com/absmach/magistrala/blob/main/users/README.md
+[conftoml]: https://github.com/absmach/supermq/blob/main/docker/addons/provision/configs/config.toml
+[users]: https://docs.supermq.absmach.eu/api/#users
 [exp]: https://github.com/absmach/export
-[cli]: https://github.com/absmach/magistrala/tree/main/cli
-[auth]: authentication
-[provision-api]: https://absmach.github.io/magistrala/?urls.primaryName=provision.yml
+[cli]: /docs/dev-guide/cli/introduction-to-cli
+[auth]: /docs/dev-guide/dev-tools/authentication
+[provision-api]: https://github.com/absmach/supermq/tree/main/provision

--- a/content/docs/dev-guide/services/provision.mdx
+++ b/content/docs/dev-guide/services/provision.mdx
@@ -393,7 +393,7 @@ For more information about the Clients service API, please check out the [API do
 
 Provisioning is a process of configuration of an IoT platform in which system operator creates and sets-up different entities used in the platform - users, channels and clients. It is part of process of setting up IoT applications where we connect devices on edge with platform in cloud. For provisioning we can use [Magistrala CLI][cli] for creating users and for each node in the edge (eg. gateway) required number of clients, channels, connecting them and creating certificates if needed. Provision service is used to set up initial application configuration once user is created. Provision service creates clients, channels, connections and certificates. Once user is created we can use provision to create a setup for edge node in one HTTP request instead of issuing several CLI commands.
 
-Provision service provides an HTTP API to interact with SuperMQ.
+Provision service provides an HTTP API to interact with [Magistrala][provision-api].
 
 For gateways to communicate with [Magistrala][magistrala] configuration is required (MQTT host, client, channels, certificates...). Gateway will send a request to [Bootstrap][bootstrap] service providing `<external_id>` and `<external_key>` in HTTP request to get the configuration. To make a request to [Bootstrap][bootstrap] service you can use [Agent][agent] service on a gateway.
 
@@ -660,12 +660,12 @@ For more information about the Provision service, please check out the [service 
 [magistrala]: https://github.com/absmach/magistrala
 [bootstrap]: /docs/dev-guide/services/bootstrap
 [agent]: https://github.com/absmach/agent
-[config]: https://github.com/absmach/supermq/tree/main/provision#configuration
-[env]: https://github.com/absmach/supermq/blob/main/docker/.env
+[config]: https://github.com/absmach/magistrala/tree/main/provision#configuration
+[env]: https://github.com/absmach/magistrala/blob/main/docker/.env
 [mgui]: https://github.com/absmach/magistrala-ui-new
-[conftoml]: https://github.com/absmach/supermq/blob/main/docker/addons/provision/configs/config.toml
+[conftoml]: https://github.com/absmach/magistrala/blob/main/docker/addons/provision/configs/config.toml
 [users]: https://docs.supermq.absmach.eu/api/#users
 [exp]: https://github.com/absmach/export
 [cli]: /docs/dev-guide/cli/introduction-to-cli
 [auth]: /docs/dev-guide/dev-tools/authentication
-[provision-api]: https://github.com/absmach/supermq/tree/main/provision
+[provision-api]: https://github.com/absmach/magistrala/tree/main/provision

--- a/content/docs/dev-guide/services/provision.mdx
+++ b/content/docs/dev-guide/services/provision.mdx
@@ -664,7 +664,7 @@ For more information about the Provision service, please check out the [service 
 [env]: https://github.com/absmach/magistrala/blob/main/docker/.env
 [mgui]: https://github.com/absmach/magistrala-ui-new
 [conftoml]: https://github.com/absmach/magistrala/blob/main/docker/addons/provision/configs/config.toml
-[users]: https://docs.supermq.absmach.eu/api/#users
+[users]: https://magistrala.absmach.eu/docs/dev-guide/services/users/
 [exp]: https://github.com/absmach/export
 [cli]: /docs/dev-guide/cli/introduction-to-cli
 [auth]: /docs/dev-guide/dev-tools/authentication

--- a/content/docs/dev-guide/services/provision.mdx
+++ b/content/docs/dev-guide/services/provision.mdx
@@ -397,10 +397,10 @@ Provision service provides an HTTP API to interact with [Magistrala][provision-a
 
 For gateways to communicate with [Magistrala][magistrala] configuration is required (MQTT host, client, channels, certificates...). Gateway will send a request to [Bootstrap][bootstrap] service providing `<external_id>` and `<external_key>` in HTTP request to get the configuration. To make a request to [Bootstrap][bootstrap] service you can use [Agent][agent] service on a gateway.
 
-To create bootstrap configuration you can use [Bootstrap][bootstrap] or `Provision` service. [Magistrala UI][mgui] uses [Bootstrap][bootstrap] service for creating gateway configurations. `Provision` service should provide an easy way of provisioning your gateways i.e creating bootstrap configuration and as many clients and channels that your setup requires.
+To create bootstrap configuration you can use [Bootstrap][bootstrap] or `Provision` service. Magistrala UI uses [Bootstrap][bootstrap] service for creating gateway configurations. `Provision` service should provide an easy way of provisioning your gateways i.e creating bootstrap configuration and as many clients and channels that your setup requires.
 
 Also, you may use provision service to create certificates for each client. Each service running on gateway may require more than one client and channel for communication.
-If, for example, you are using services [Agent][agent] and [Export][exp] on a gateway you will need two channels for `Agent` (`data` and `control`) and one client for `Export`.
+If, for example, you are using services [Agent][agent] and Export on a gateway you will need two channels for `Agent` (`data` and `control`) and one client for `Export`.
 Additionally, if you enabled mTLS each service will need its own client and certificate for access to [Magistrala][magistrala].
 Your setup could require any number of clients and channels, this kind of setup we can call `provision layout`.
 
@@ -514,12 +514,12 @@ Example of provision layout below
 ### Authentication
 
 In order to create necessary entities provision service needs to authenticate against Magistrala.
-To provide authentication credentials to the provision service you can pass it in as an environment variable or in a config file as Magistrala user and password or as API token (that can be issued on `/users/tokens/issue` endpoint of [users service][users].
+To provide authentication credentials to the provision service you can pass them in as environment variables, in a config file as Magistrala user credentials, or as an API token issued on the `/users/tokens/issue` endpoint of the [users service][users].
 
 Additionally, users or API token can be passed in Authorization header, this authentication takes precedence over others.
 
-- `username`, `password` - (`MG_PROVISION_USER`, `MG_PROVISION_PASSWORD` in [.env][env], `MG_user`, `MG_pass` in [config.toml][conftoml]
-- API Key - (`MG_PROVISION_API_KEY` in [.env][env] or [config.toml][conftoml]
+- `username`, `password` - (`MG_PROVISION_USER`, `MG_PROVISION_PASSWORD` in [.env][env], `MG_user`, `MG_pass` in [config.toml][conftoml])
+- API Key - (`MG_PROVISION_API_KEY` in [.env][env] or [config.toml][conftoml])
 - `Authorization: Bearer Token|ApiKey` - request authorization header containing users token. Check [auth][auth].
 
 ### Running
@@ -662,10 +662,8 @@ For more information about the Provision service, please check out the [service 
 [agent]: https://github.com/absmach/agent
 [config]: https://github.com/absmach/magistrala/tree/main/provision#configuration
 [env]: https://github.com/absmach/magistrala/blob/main/docker/.env
-[mgui]: https://github.com/absmach/magistrala-ui-new
 [conftoml]: https://github.com/absmach/magistrala/blob/main/docker/addons/provision/configs/config.toml
-[users]: https://magistrala.absmach.eu/docs/dev-guide/services/users/
-[exp]: https://github.com/absmach/export
+[users]: /docs/dev-guide/services/users
 [cli]: /docs/dev-guide/cli/introduction-to-cli
 [auth]: /docs/dev-guide/dev-tools/authentication
 [provision-api]: https://github.com/absmach/magistrala/tree/main/provision

--- a/content/docs/dev-guide/services/reports.mdx
+++ b/content/docs/dev-guide/services/reports.mdx
@@ -25,7 +25,7 @@ The Reports Service operates through three main components:
 
 ![reports_architecture](../../diagrams/reports_architecture.svg)
 
-> **Note:** All API operations require appropriate role-based permissions. Refer to the [Roles Schema](../roles-schema#reports) for details on available roles and the permissions they grant.
+> **Note:** All API operations require appropriate role-based permissions. Refer to the [Roles Schema](/docs/dev-guide/roles-schema#reports) for details on available roles and the permissions they grant.
 
 ## Reports Service Architecture
 

--- a/content/docs/dev-guide/services/rules-engine.mdx
+++ b/content/docs/dev-guide/services/rules-engine.mdx
@@ -21,7 +21,7 @@ The **Rules Engine** in Magistrala provides powerful, flexible message processin
 1. **Scriptable logic** - Use Lua or Go to define message execution behavior.
 2. **Flexible execution** - Rules can be triggered from input messages, schedules or both.
 3. **Pluggable outputs** - Built-in support for alarms, channels, email, Postgres, and SenML writers.
-4. **Secure, scoped execution** - Using domain-level isolation and bearer token authorization. See the [Roles Schema](../roles-schema) for details on available roles and permissions.
+4. **Secure, scoped execution** - Using domain-level isolation and bearer token authorization. See the [Roles Schema](/docs/dev-guide/roles-schema) for details on available roles and permissions.
 5. **Disabled rules** - Rules can be disabled individually to prevent further executions. They can also be enabled to re-start their executions.
 
 ## Architecture
@@ -63,7 +63,7 @@ The Magistrala Rules Engine is designed for **real-time** and **scheduled messag
 - _Email_ - Send notifications to configured recipients.
 - _Slack_ - Send notifications to configured slack channel.
 
-> **Note:** Access to each operation is governed by domain-level roles. Refer to the [Roles Schema](../roles-schema#rules) for details on which permissions are required.
+> **Note:** Access to each operation is governed by domain-level roles. Refer to the [Roles Schema](/docs/dev-guide/roles-schema#rules) for details on which permissions are required.
 
 ## Core Concepts
 

--- a/content/docs/user-guide/architecture.mdx
+++ b/content/docs/user-guide/architecture.mdx
@@ -47,6 +47,8 @@ Magistrala platform can be run on the edge as well. Deploying Magistrala on a ga
 
 Running Magistrala on gateway moves computation from cloud towards the edge thus decentralizing IoT system. Since we can deploy same Magistrala code on gateway and in the cloud there are many benefits but the biggest one is easy deployment and adoption - once engineers understand how to deploy and maintain the platform, they will be able to apply those same skills to any part of the edge-fog-cloud continuum. This is because the platform is designed to be consistent, making it easy for engineers to move between them. This consistency will save engineers time and effort, and it will also help to improve the reliability and security of the platform. Same set of tools can be used, same patches and bug fixes can be applied. The whole system is much easier to reason about, and the maintenance is much easier and less costly.
 
+[mqtt-adapter]: /docs/dev-guide/dev-tools/messaging#mqtt
+[magistrala-cli]: /docs/dev-guide/cli/introduction-to-cli
 [nats]: https://nats.io/
 [rabbitmq]: https://www.rabbitmq.com/
 [vernemq]: https://vernemq.com/
@@ -54,3 +56,10 @@ Running Magistrala on gateway moves computation from cloud towards the edge thus
 [senml]: https://tools.ietf.org/html/draft-ietf-core-senml-08
 [agent]: /docs/dev-guide/edge#agent
 [export]: /docs/dev-guide/edge#export
+[bootstrap]: /docs/dev-guide/services/bootstrap
+[consumers]: /docs/dev-guide/services/consumers
+[email]: https://pkg.go.dev/github.com/absmach/supermq-contrib/pkg/email
+[provision]: /docs/dev-guide/services/provision
+[rules-engine]: /docs/dev-guide/services/rules-engine
+[readers]: /docs/dev-guide/dev-tools/storage#readers
+[supermq]: https://github.com/absmach/supermq

--- a/content/docs/user-guide/architecture.mdx
+++ b/content/docs/user-guide/architecture.mdx
@@ -58,7 +58,7 @@ Running Magistrala on gateway moves computation from cloud towards the edge thus
 [export]: /docs/dev-guide/edge#export
 [bootstrap]: /docs/dev-guide/services/bootstrap
 [consumers]: /docs/dev-guide/services/consumers
-[email]: https://pkg.go.dev/github.com/absmach/supermq-contrib/pkg/email
+[email]: https://github.com/absmach/magistrala-contrib/tree/main/pkg/email
 [provision]: /docs/dev-guide/services/provision
 [rules-engine]: /docs/dev-guide/services/rules-engine
 [readers]: /docs/dev-guide/dev-tools/storage#readers

--- a/content/docs/user-guide/architecture.mdx
+++ b/content/docs/user-guide/architecture.mdx
@@ -12,7 +12,7 @@ image: /img/mg-preview.png
 
 ## Components
 
-Magistrala IoT platform is comprised of core services (auth, users, groups, clients, channels, domains, protocol adapters) together with additional services such as bootstrap, provision, consumers, readers, and the rules engine. For the full component reference, see the [Architecture page in the Dev Guide](/docs/dev-guide/architecture).
+Magistrala IoT platform is comprised of core services (auth, users, groups, clients, channels, domains, and messaging services) together with additional services such as bootstrap, provision, consumers, readers, and the rules engine. For the full component reference, see the [Architecture page in the Dev Guide](/docs/dev-guide/architecture).
 
 ![arch](../img/architecture.svg)
 
@@ -38,28 +38,17 @@ In general, there is no constraint put on content that is being exchanged throug
 
 ## Edge
 
-Magistrala platform can be run on the edge as well. Deploying Magistrala on a gateway makes it able to collect, store and analyze data, organize and authenticate devices. To connect Magistrala instances running on a gateway with Magistrala in a cloud we can use two gateway services developed for that purpose:
+Magistrala platform can be run on the edge as well. Deploying Magistrala on a gateway makes it able to collect, store and analyze data, organize and authenticate devices. To connect Magistrala instances running on a gateway with Magistrala in a cloud we can use the following gateway service:
 
 - [Agent][agent]
-- [Export][export]
 
 ## Unified IoT Platform
 
 Running Magistrala on gateway moves computation from cloud towards the edge thus decentralizing IoT system. Since we can deploy same Magistrala code on gateway and in the cloud there are many benefits but the biggest one is easy deployment and adoption - once engineers understand how to deploy and maintain the platform, they will be able to apply those same skills to any part of the edge-fog-cloud continuum. This is because the platform is designed to be consistent, making it easy for engineers to move between them. This consistency will save engineers time and effort, and it will also help to improve the reliability and security of the platform. Same set of tools can be used, same patches and bug fixes can be applied. The whole system is much easier to reason about, and the maintenance is much easier and less costly.
 
-[mqtt-adapter]: /docs/dev-guide/dev-tools/messaging#mqtt
-[magistrala-cli]: /docs/dev-guide/cli/introduction-to-cli
 [nats]: https://nats.io/
 [rabbitmq]: https://www.rabbitmq.com/
 [vernemq]: https://vernemq.com/
 [kafka]: https://kafka.apache.org/
 [senml]: https://tools.ietf.org/html/draft-ietf-core-senml-08
 [agent]: /docs/dev-guide/edge#agent
-[export]: /docs/dev-guide/edge#export
-[bootstrap]: /docs/dev-guide/services/bootstrap
-[consumers]: /docs/dev-guide/services/consumers
-[email]: https://github.com/absmach/magistrala-contrib/tree/main/pkg/email
-[provision]: /docs/dev-guide/services/provision
-[rules-engine]: /docs/dev-guide/services/rules-engine
-[readers]: /docs/dev-guide/dev-tools/storage#readers
-[supermq]: https://github.com/absmach/supermq

--- a/content/docs/user-guide/messaging.mdx
+++ b/content/docs/user-guide/messaging.mdx
@@ -239,7 +239,7 @@ it's subtopics.
 
 **Note:** When using MQTT, it's recommended that you use standard MQTT wildcards `+` and `#`.
 
-[http-api]: https://docs.api.magistrala.absmach.eu/?urls.primaryName=api%2Fhttp.yaml
+[http-api]: https://docs.api.magistrala.absmach.eu/?urls.primaryName=api%2Fhttp.yaml&service=http.yaml#/
 [mosquitto]: https://mosquitto.org
 [paho]: https://www.eclipse.org/paho/
 [rfc7252]: https://tools.ietf.org/html/rfc7252

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -69,7 +69,7 @@ export const softwareApplicationSchema = {
   license: "https://www.apache.org/licenses/LICENSE-2.0",
   url: DOMAIN,
   downloadUrl: "https://github.com/absmach/magistrala",
-  releaseNotes: `${DOMAIN}/docs/changelog`,
+  releaseNotes: "https://github.com/absmach/magistrala/releases",
   screenshot: [
     {
       "@type": "ImageObject",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "next build",
-    "dev": "next dev",
+    "dev": "NODE_OPTIONS='--max-old-space-size=3072' next dev",
     "start": "serve out",
     "preview": "next build && wrangler dev",
     "cf:dev": "next build && wrangler dev",


### PR DESCRIPTION
<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->
# What type of PR is this?

This is a documentation update because it fixes broken internal links, replaces dead external documentation links, and refreshes outdated references across the docs.

<!--
This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?
Updates docs across `user-guide`, `dev-guide`, and related app metadata so links resolve correctly and point to live destinations. This includes:
- fixing broken internal `/docs/...` navigation
- replacing dead external API-host links with live SuperMQ docs pages
- updating outdated source links from old Magistrala paths to current SuperMQ or contrib locations
- refreshing stale LoRa references from old LoRa Server pages to current ChirpStack documentation
- correcting the structured-data `releaseNotes` URL to a real existing page

## Which issue(s) does this PR fix/relate to?
<!--
- Related Issue #
- Resolves #
-->
N/A
## Have you included tests for your changes?

Tested Manually
## Did you document any new/modified features?


### Notes

